### PR TITLE
Update deprecated Ansible flag

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -31,7 +31,7 @@
   register: current_ruby_version
   failed_when: false
   changed_when: false
-  always_run: true
+  check_mode: no
 
 - name: Download ruby.
   get_url:


### PR DESCRIPTION
As of Ansible 2.2, `always_run` was flagged as deprecated, with `check_mode` replacing it. As of Ansible 2.6, this was hard-deprecated, so won't work on any Ansible version 2.6 onwards.